### PR TITLE
Speed up file collection

### DIFF
--- a/src/makegrind/__main__.py
+++ b/src/makegrind/__main__.py
@@ -14,7 +14,7 @@
 import datetime
 import os
 import sys
-import glob
+import from pathlib import Path
 import multiprocessing as mp
 import logging
 
@@ -69,7 +69,7 @@ def find_json_files(ctx, param, value):
             paths.append(path)
         else:
             paths.extend(
-                glob.glob(os.path.join(path, "**", "build.*.json"), recursive=True)
+                paths.extend([str(file) for file in Path(path).rglob("build.*.json")])
             )
 
     if not paths:


### PR DESCRIPTION
Significant speed up when collecting files spread across many directories.

In my case I have 1687 `build.*.json` files spread across 45764 directories. Before this change, collection never completed for me (waiting for 10+ minutes). After this change, collection appears instantaneous.

remake does provide the `--profile-directory` but that can not be applied retroactively.