### PR TITLE
add `chrome-tracing` export

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ to display possible options.
 * paths: Generates listing of dependency path taking the longest time
 * dirs: Generates statistics over each directory
 * recipes: Generates statistics on recipes taking the longest time
-* callgrind: Generates an aggregate callgrind.out file
+* callgrind: Generates an aggregate callgrind.out.target file
+* chrome-tracing: Generates an aggregate chrome-tracing.out.targets file
+  * You can view this either by using `chrome://tracing/` in your Chrome browser
+    or visiting https://www.speedscope.app/.
 
 ## Reports
 

--- a/src/makegrind/__main__.py
+++ b/src/makegrind/__main__.py
@@ -139,6 +139,21 @@ def callgrind(graph, outfile):
 
 @main.command()
 @click.option(
+    "-o",
+    "--output",
+    "outfile",
+    type=click.File("w"),
+    default="chrome_tracing.out.targets",
+)
+@click.pass_obj
+def chrome_tracing(graph, outfile):
+    """Generate a single chrome-traching-formatted file from combined build.json files"""
+    logging.info("Generating chrome-traching file")
+    makegrind.dump_chrome_tracing(graph, outfile)
+
+
+@main.command()
+@click.option(
     "-t",
     "--target",
     help="Ensure target is within the path found. Formatted as TARGET:MAKEFILE:PID",


### PR DESCRIPTION
I've tested this with `chrome://tracing/` and https://www.speedscope.app/ with a non-recursive makefile build. Not sure how this performs with a recursive build.

A parallel build produces overlapping trace elements as the `remake` profile (of a non-recursive build) does not include a "thread" distinguishing feature.

See also: 
-  https://github.com/jlfwong/speedscope/wiki/Importing-from-custom-sources#google-trace-event-format
- https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview#heading=h.xqopa5m0e28f